### PR TITLE
Upgrade ccxt, now with building confirmed

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "ccxt": "1.57.82",
     "class-transformer": "0.4.0",
     "class-transformer-validator": "0.9.1",
-    "class-validator": "0.13.1",
+    "class-validator": "0.13.2",
     "express": "4.17.1",
     "handy-redis": "2.3.1",
     "node-json-db": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@types/node": "16.10.3",
     "@types/redis": "2.8.32",
     "@types/uuid": "8.3.1",
+    "@types/validator": "^13.7.1",
     "@typescript-eslint/eslint-plugin": "4.33.0",
     "@typescript-eslint/parser": "4.33.0",
     "concurrently": "6.3.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     ]
   },
   "dependencies": {
-    "ccxt": "1.57.82",
+    "ccxt": "1.68.20",
     "class-transformer": "0.4.0",
     "class-transformer-validator": "0.9.1",
     "class-validator": "0.13.2",


### PR DESCRIPTION
1. Update `class-validator` to address moderate issue flagged by `npm audit`
2. Update `@types/validator` to address build issue resulting from number 1 above
3. Update `ccxt` in hopes that it addresses ftx issues (confirmed to at least work with querying balances for BinanceUs)